### PR TITLE
Update mobile grids

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
     <div class="max-w-5xl mx-auto px-8 text-center">
       <h2 class="text-4xl font-bold mb-12">Menu Highlights</h2>
       <h3 class="text-2xl font-semibold mb-6 text-center">Signature Espresso &amp; Specialty Drinks</h3>
-      <div class="grid gap-10 md:grid-cols-3">
+      <div class="grid grid-cols-2 gap-10 md:grid-cols-3">
         <!-- Brown Cow -->
         <div data-aos="zoom-in" class="p-8 border border-gray-200 rounded-lg shadow-sm hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Brown Cow</h4>
@@ -112,7 +112,7 @@
       </div>
 
       <h3 class="text-2xl font-semibold mt-12 mb-6 text-center">Cold Craft &amp; Refreshers</h3>
-      <div class="grid gap-10 md:grid-cols-2">
+      <div class="grid grid-cols-2 gap-10 md:grid-cols-2">
         <!-- Dragonfruit Lychee Lemonade Refresher -->
         <div data-aos="zoom-in" class="p-8 border border-gray-200 rounded-lg shadow-sm hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Dragonfruit Lychee Lemonade Refresher</h4>
@@ -126,7 +126,7 @@
       </div>
 
       <h3 class="text-2xl font-semibold mt-12 mb-6 text-center">Scratch-Made Pastries</h3>
-      <div class="grid gap-10 md:grid-cols-2">
+      <div class="grid grid-cols-2 gap-10 md:grid-cols-2">
         <!-- Bacon-Cheddar Scone -->
         <div data-aos="zoom-in" class="p-8 border border-gray-200 rounded-lg shadow-sm hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Bacon-Cheddar Scone</h4>
@@ -145,7 +145,7 @@
   <section id="gallery" class="py-20 bg-gray-50">
     <div class="max-w-5xl mx-auto px-8">
       <h2 class="text-4xl font-bold text-center mb-12">Behind the Beans</h2>
-      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div class="grid grid-cols-2 gap-6 lg:grid-cols-3">
         <img data-aos="fade-up" src="https://images.unsplash.com/photo-1532635223-59673d3ac2e0?auto=format&fit=crop&w=600&q=80" alt="Fresh latte art" class="rounded-lg shadow-md">
         <img data-aos="fade-up" src="https://images.unsplash.com/photo-1512568400610-62da28bc8a13?auto=format&fit=crop&w=600&q=80" alt="Pastry display" class="rounded-lg shadow-md">
         <img data-aos="fade-up" src="https://images.unsplash.com/photo-1600891964599-f61ba0e24092?auto=format&fit=crop&w=600&q=80" alt="Pour-over coffee" class="rounded-lg shadow-md">


### PR DESCRIPTION
## Summary
- make menu highlight grid two columns by default for mobile
- set gallery grid to show two columns on small screens

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858138c101083299f34251af6538c11