### PR TITLE
Fix testimonial swiper height

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,6 +224,7 @@
       loop: true,
       autoplay: { delay: 5000, disableOnInteraction: false },
       allowTouchMove: false,
+      autoHeight: true,
       slidesPerView: 1,
       spaceBetween: 20,
       breakpoints: {


### PR DESCRIPTION
## Summary
- enable `autoHeight` for testimonial carousel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685819c05f548329872cdf05aba58e80