### PR TITLE
Style menu cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,32 +89,32 @@
       <h3 class="text-2xl font-semibold mb-6 text-center">Signature Espresso &amp; Specialty Drinks</h3>
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
         <!-- Brown Cow -->
-        <div data-aos="zoom-in" class="text-center p-4 md:p-6 border border-[var(--brand-dark)/20] rounded-lg shadow-sm hover:shadow-lg transition">
+        <div data-aos="zoom-in" class="text-center p-4 md:p-6 rounded-lg bg-white/80 shadow-md hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Brown Cow</h4>
           <p class="text-sm">Fresh-pulled espresso shaken with silky house sweet cream for pure, mellow comfort.</p>
         </div>
         <!-- Honeymoon -->
-        <div data-aos="zoom-in" class="text-center p-4 md:p-6 border border-[var(--brand-dark)/20] rounded-lg shadow-sm hover:shadow-lg transition">
+        <div data-aos="zoom-in" class="text-center p-4 md:p-6 rounded-lg bg-white/80 shadow-md hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Honeymoon</h4>
           <p class="text-sm">Pineapple-coconut iced latte that tastes like bottled sunshine.</p>
         </div>
         <!-- Honey Lavender Latte -->
-        <div data-aos="zoom-in" class="text-center p-4 md:p-6 border border-[var(--brand-dark)/20] rounded-lg shadow-sm hover:shadow-lg transition">
+        <div data-aos="zoom-in" class="text-center p-4 md:p-6 rounded-lg bg-white/80 shadow-md hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Honey Lavender Latte</h4>
           <p class="text-sm">Floral lavender, local honey, and textured milk—hot or iced.</p>
         </div>
         <!-- Irish Crème Breve -->
-        <div data-aos="zoom-in" class="text-center p-4 md:p-6 border border-[var(--brand-dark)/20] rounded-lg shadow-sm hover:shadow-lg transition">
+        <div data-aos="zoom-in" class="text-center p-4 md:p-6 rounded-lg bg-white/80 shadow-md hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Irish Crème Breve</h4>
           <p class="text-sm">Espresso and velvety half-and-half kissed with Irish crème syrup.</p>
         </div>
         <!-- Spiced Caramel Latte -->
-        <div data-aos="zoom-in" class="text-center p-4 md:p-6 border border-[var(--brand-dark)/20] rounded-lg shadow-sm hover:shadow-lg transition">
+        <div data-aos="zoom-in" class="text-center p-4 md:p-6 rounded-lg bg-white/80 shadow-md hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Spiced Caramel Latte</h4>
           <p class="text-sm">House caramel blended with warm baking spices for year-round autumn vibes.</p>
         </div>
         <!-- Coconut Truffle Latte -->
-        <div data-aos="zoom-in" class="text-center p-4 md:p-6 border border-[var(--brand-dark)/20] rounded-lg shadow-sm hover:shadow-lg transition">
+        <div data-aos="zoom-in" class="text-center p-4 md:p-6 rounded-lg bg-white/80 shadow-md hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Coconut Truffle Latte</h4>
           <p class="text-sm">A creamy tropical escape of house-made coconut and rich chocolate.</p>
         </div>
@@ -123,12 +123,12 @@
       <h3 class="text-2xl font-semibold mt-12 mb-6 text-center">Cold Craft &amp; Refreshers</h3>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <!-- Dragonfruit Lychee Lemonade Refresher -->
-        <div data-aos="zoom-in" class="text-center p-4 md:p-6 border border-[var(--brand-dark)/20] rounded-lg shadow-sm hover:shadow-lg transition">
+        <div data-aos="zoom-in" class="text-center p-4 md:p-6 rounded-lg bg-white/80 shadow-md hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Dragonfruit Lychee Lemonade Refresher</h4>
           <p class="text-sm">Vibrant ruby color, tropical snap, zero caffeine.</p>
         </div>
         <!-- Iced Marble Mocha -->
-        <div data-aos="zoom-in" class="text-center p-4 md:p-6 border border-[var(--brand-dark)/20] rounded-lg shadow-sm hover:shadow-lg transition">
+        <div data-aos="zoom-in" class="text-center p-4 md:p-6 rounded-lg bg-white/80 shadow-md hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Iced Marble Mocha</h4>
           <p class="text-sm">Dark + white chocolate swirled over bold espresso.</p>
         </div>
@@ -137,12 +137,12 @@
       <h3 class="text-2xl font-semibold mt-12 mb-6 text-center">Scratch-Made Pastries</h3>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <!-- Bacon-Cheddar Scone -->
-        <div data-aos="zoom-in" class="text-center p-4 md:p-6 border border-[var(--brand-dark)/20] rounded-lg shadow-sm hover:shadow-lg transition">
+        <div data-aos="zoom-in" class="text-center p-4 md:p-6 rounded-lg bg-white/80 shadow-md hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Bacon-Cheddar Scone</h4>
           <p class="text-sm">Savory-crisp, baked at dawn.</p>
         </div>
         <!-- Legendary Cinnamon Rolls -->
-        <div data-aos="zoom-in" class="text-center p-4 md:p-6 border border-[var(--brand-dark)/20] rounded-lg shadow-sm hover:shadow-lg transition">
+        <div data-aos="zoom-in" class="text-center p-4 md:p-6 rounded-lg bg-white/80 shadow-md hover:shadow-lg transition">
           <h4 class="text-xl font-semibold mb-2">Legendary Cinnamon Rolls</h4>
           <p class="text-sm">Gooey spirals that sell out fast—ask early!</p>
         </div>


### PR DESCRIPTION
## Summary
- soften visual style of menu highlight cards by dropping rigid borders
- give the cards a subtle translucent white background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858215c8d908329b173ac50315bbb5e