### PR TITLE
Reduce overlay size of mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
         <img src="assets/logo.png" alt="Shouting Grounds Coffee Co. logo" class="h-16">
       </a>
       <button id="nav-toggle" class="md:hidden text-3xl" aria-label="Toggle navigation">&#9776;</button>
-      <div id="nav-menu" class="hidden fixed inset-0 flex flex-col items-center justify-center space-y-8 text-lg bg-[var(--brand-light)] md:static md:flex md:flex-row md:space-y-0 md:space-x-8 md:bg-transparent md:p-0 md:shadow-none">
+      <div id="nav-menu" class="hidden absolute left-0 right-0 top-full z-10 flex flex-col items-center space-y-4 py-4 text-lg bg-[var(--brand-light)] shadow-md md:static md:flex md:flex-row md:space-y-0 md:space-x-8 md:bg-transparent md:p-0 md:shadow-none">
         <a href="#about" class="block md:inline hover:text-[var(--brand-accent)]">About</a>
         <a href="#menu" class="block md:inline hover:text-[var(--brand-accent)]">Menu</a>
         <a href="#gallery" class="block md:inline hover:text-[var(--brand-accent)]">Gallery</a>


### PR DESCRIPTION
## Summary
- adjust mobile nav classes so the menu is a dropdown instead of full-screen

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68582f44c4908329b55bd6304652915a