### PR TITLE
Fix Get Directions link

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
           <li>Sat        : 7:30 AM – 5 PM</li>
           <li>Sun        : Closed</li>
         </ul>
-        <a href="https://maps.app.goo.gl/Urs7KhQNfEtvX23h6" target="_blank" class="inline-block mt-8 bg-[var(--brand-accent)] hover:bg-[var(--brand-accent)]/90 text-white py-3 px-6 rounded-full shadow transition">Get Directions</a>
+        <a href="https://www.google.com/maps/dir/?api=1&destination=22735+Antique+Ln,+New+Caney,+TX+77357" target="_blank" class="inline-block mt-8 bg-[var(--brand-accent)] hover:bg-[var(--brand-accent)]/90 text-white py-3 px-6 rounded-full shadow transition">Get Directions</a>
       </div>
       <!-- Map -->
       <div class="w-full aspect-video rounded-lg shadow-lg overflow-hidden">


### PR DESCRIPTION
## Summary
- update the Get Directions link to point directly to Google Maps directions for the cafe

## Testing
- `curl -I https://www.google.com/maps/dir/?api=1&destination=22735+Antique+Ln,+New+Caney,+TX+77357`

------
https://chatgpt.com/codex/tasks/task_e_685841bbfbd08329aa85aeac62b467b8