### PR TITLE
Fix mobile footer layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,8 +229,8 @@
   <!-- FOOTER -->
   <footer class="bg-[var(--brand-dark)] text-[var(--brand-light)] py-10">
     <div class="max-w-5xl mx-auto px-8 flex flex-col md:flex-row justify-between items-center space-y-6 md:space-y-0">
-      <p>&copy; <span id="year"></span> Shouting Grounds Coffee Co. All rights reserved.</p>
-      <div class="flex space-x-6 text-xl text-[var(--brand-light)]">
+      <p class="order-2 md:order-1">&copy; <span id="year"></span> Shouting Grounds Coffee Co. All rights reserved.</p>
+      <div class="flex space-x-6 text-xl text-[var(--brand-light)] order-1 md:order-2">
         <a aria-label="Facebook" href="https://www.facebook.com/Shouting-Grounds-Coffee-Company-61566595817025/" class="hover:text-white">
           <svg class="w-5 h-5 fill-current" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <title>Facebook</title>


### PR DESCRIPTION
## Summary
- ensure copyright text appears below social icons on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68586d9d9790832993abf6514f4c8409