### PR TITLE
Fix footer spacing on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
 
   <!-- FOOTER -->
   <footer class="bg-[var(--brand-dark)] text-[var(--brand-light)] py-10">
-    <div class="max-w-5xl mx-auto px-8 flex flex-col md:flex-row justify-between items-center space-y-6 md:space-y-0">
+    <div class="max-w-5xl mx-auto px-8 flex flex-col md:flex-row justify-between items-center space-y-8 md:space-y-0">
       <p class="order-2 md:order-1">&copy; <span id="year"></span> Shouting Grounds Coffee Co. All rights reserved.</p>
       <div class="flex space-x-6 text-xl text-[var(--brand-light)] order-1 md:order-2">
         <a aria-label="Facebook" href="https://www.facebook.com/Shouting-Grounds-Coffee-Company-61566595817025/" class="hover:text-white">


### PR DESCRIPTION
## Summary
- increase the vertical gap between the copyright line and social icons on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858ba9ac74483298e6d216953cad03d