### PR TITLE
Fix mobile footer spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
 
   <!-- FOOTER -->
   <footer class="bg-[var(--brand-dark)] text-[var(--brand-light)] py-10">
-    <div class="max-w-5xl mx-auto px-8 flex flex-col md:flex-row justify-between items-center space-y-8 md:space-y-0">
+    <div class="max-w-5xl mx-auto px-8 flex flex-col md:flex-row md:justify-between items-center space-y-8 md:space-y-0">
       <p class="order-2 md:order-1">&copy; <span id="year"></span> Shouting Grounds Coffee Co. All rights reserved.</p>
       <div class="flex space-x-6 text-xl text-[var(--brand-light)] order-1 md:order-2">
         <a aria-label="Facebook" href="https://www.facebook.com/Shouting-Grounds-Coffee-Company-61566595817025/" class="hover:text-white">


### PR DESCRIPTION
## Summary
- restore vertical spacing between copyright notice and social icons on mobile

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6858bb79622883298990cd3793272bcd