### PR TITLE
Fix horizontal scrolling on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
     }
   </style>
 </head>
-  <body class="text-[var(--brand-dark)] bg-[var(--brand-dark)]">
+  <body class="overflow-x-hidden text-[var(--brand-dark)] bg-[var(--brand-dark)]">
 
   <!-- NAVIGATION -->
   <nav class="fixed top-0 w-full z-20 bg-[var(--brand-light)] text-[var(--brand-dark)] shadow-sm py-3">


### PR DESCRIPTION
## Summary
- clamp horizontal overflow by applying `overflow-x-hidden` to the `<body>` tag

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68595cae0914832987b8427f047c8499