### PR TITLE
Adjust footer text size on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
           <img src="assets/yelp.svg" alt="Yelp" class="w-5 h-5" />
         </a>
       </div>
-      <div class="text-center">
+      <div class="text-center text-xs md:text-base">
         <p>&copy; <span id="year">2025</span> Shouting Grounds Coffee Co. — All rights reserved.</p>
         <p>Designed, hosted, and supported by <a href="https://liftoff.guru" class="underline">Liftoff.Guru</a> in Texas, USA.</p>
       </div>


### PR DESCRIPTION
## Summary
- shrink footer text size so copyright text only takes two lines on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859674192108329b9512d9821d64916