### PR TITLE
Fix layout overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,9 +29,13 @@
   <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
   <style>
   body { margin: 0; }
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
     html {
       font-family: Inter, sans-serif;
       scroll-padding-top: 6rem;
+      overflow-x: hidden;
     }
     h1, h2, h3 { font-family: 'Playfair Display', serif; }
     :root {


### PR DESCRIPTION
## Summary
- prevent horizontal overflow with border-box global style
- hide extra width on html element

## Testing
- `tidy -errors index.html`

------
https://chatgpt.com/codex/tasks/task_e_685975e8415883298274e6c1f16f2ea8