### PR TITLE
Remove gallery image animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,32 +202,32 @@
         <div class="swiper-wrapper">
           <div class="swiper-slide">
             <div class="bg-white rounded-lg shadow-md overflow-hidden">
-              <img data-aos="fade-up" src="assets/gallery1.jpg" alt="Fresh latte art" class="w-full h-48 object-cover">
+              <img src="assets/gallery1.jpg" alt="Fresh latte art" class="w-full h-48 object-cover">
             </div>
           </div>
           <div class="swiper-slide">
             <div class="bg-white rounded-lg shadow-md overflow-hidden">
-              <img data-aos="fade-up" src="assets/gallery2.jpg" alt="Pastry display" class="w-full h-48 object-cover">
+              <img src="assets/gallery2.jpg" alt="Pastry display" class="w-full h-48 object-cover">
             </div>
           </div>
           <div class="swiper-slide">
             <div class="bg-white rounded-lg shadow-md overflow-hidden">
-              <img data-aos="fade-up" src="assets/gallery3.jpg" alt="Pour-over coffee" class="w-full h-48 object-cover">
+              <img src="assets/gallery3.jpg" alt="Pour-over coffee" class="w-full h-48 object-cover">
             </div>
           </div>
           <div class="swiper-slide">
             <div class="bg-white rounded-lg shadow-md overflow-hidden">
-              <img data-aos="fade-up" src="assets/gallery4.jpg" alt="Smoothie bowl" class="w-full h-48 object-cover">
+              <img src="assets/gallery4.jpg" alt="Smoothie bowl" class="w-full h-48 object-cover">
             </div>
           </div>
           <div class="swiper-slide">
             <div class="bg-white rounded-lg shadow-md overflow-hidden">
-              <img data-aos="fade-up" src="assets/gallery5.jpg" alt="Espresso machine" class="w-full h-48 object-cover">
+              <img src="assets/gallery5.jpg" alt="Espresso machine" class="w-full h-48 object-cover">
             </div>
           </div>
           <div class="swiper-slide">
             <div class="bg-white rounded-lg shadow-md overflow-hidden">
-              <img data-aos="fade-up" src="assets/gallery6.jpg" alt="Cafe interior" class="w-full h-48 object-cover">
+              <img src="assets/gallery6.jpg" alt="Cafe interior" class="w-full h-48 object-cover">
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove `data-aos` attributes from the images in **Behind the Beans** gallery

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688698b9b12c8329acf435daf7e422b2