### PR TITLE
Fix navigation on privacy page

### DIFF
--- a/privacy/index.html
+++ b/privacy/index.html
@@ -69,15 +69,15 @@
   <!-- NAVIGATION -->
   <nav class="fixed top-0 w-full z-20 bg-[var(--brand-light)] text-[var(--brand-dark)] shadow-sm py-3">
     <div class="relative max-w-6xl mx-auto px-8 flex items-center justify-between ">
-      <a href="#home">
-        <img src="assets/logo.png" alt="Shouting Grounds Coffee Co. logo" class="h-16">
+      <a href="/">
+        <img src="/assets/logo.png" alt="Shouting Grounds Coffee Co. logo" class="h-16">
       </a>
       <button id="nav-toggle" class="md:hidden text-3xl" aria-label="Toggle navigation">&#9776;</button>
       <div id="nav-menu" class="hidden absolute left-0 right-0 top-full z-10 flex flex-col items-center space-y-4 py-4 text-lg bg-[var(--brand-light)] shadow-md md:static md:flex md:flex-row md:space-y-0 md:space-x-8 md:bg-transparent md:p-0 md:shadow-none">
-        <a href="#about" class="block md:inline hover:text-[var(--brand-accent)]">About</a>
-        <a href="#menu" class="block md:inline hover:text-[var(--brand-accent)]">Menu</a>
-        <a href="#gallery" class="block md:inline hover:text-[var(--brand-accent)]">Gallery</a>
-        <a href="#visit" class="block md:inline hover:text-[var(--brand-accent)]">Visit</a>
+          <a href="/#about" class="block md:inline hover:text-[var(--brand-accent)]">About</a>
+          <a href="/#menu" class="block md:inline hover:text-[var(--brand-accent)]">Menu</a>
+          <a href="/#gallery" class="block md:inline hover:text-[var(--brand-accent)]">Gallery</a>
+          <a href="/#visit" class="block md:inline hover:text-[var(--brand-accent)]">Visit</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- fix logo path and make nav links go to home page from `/privacy`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68869f52c0b083299d30aed697dbb9f7