### PR TITLE
Improve privacy page formatting

### DIFF
--- a/privacy/index.html
+++ b/privacy/index.html
@@ -84,17 +84,30 @@
 
   <main class="pt-24 pb-16 bg-[var(--brand-light-alt)]">
     <div class="max-w-4xl mx-auto px-8 space-y-4 text-lg">
-      <h1 class="text-4xl font-bold mb-4">Privacy Policy</h1>
+      <h1 class="text-4xl font-bold mb-4 text-center">Privacy Policy</h1>
       <p><strong>Shouting Grounds Coffee&nbsp;Co.</strong></p>
       <p class="italic">Last updated: [Month&nbsp;Day,&nbsp;2025]</p>
       <p>Shouting Grounds Coffee&nbsp;Co. (“Shouting&nbsp;Grounds,” “we,” “our,” or “us”) values your privacy. This Privacy&nbsp;Policy explains how we collect, use, disclose, and safeguard the only personal information we request on our website—your name and email address—when you use our Contact&nbsp;Us form. By visiting the site or submitting information, you agree to the practices described below.</p>
       <h2 class="text-2xl font-semibold mt-6">1. Information&nbsp;We&nbsp;Collect&nbsp;&amp;&nbsp;Why</h2>
-      <table class="min-w-full text-left border border-gray-300">
+      <table class="min-w-full text-left border border-gray-300 my-4">
         <thead class="bg-gray-100">
-          <tr><th class="border p-2">Type</th><th class="border p-2">Details Collected</th><th class="border p-2">Purpose</th></tr>
+          <tr>
+            <th class="border p-2">Type</th>
+            <th class="border p-2">Details Collected</th>
+            <th class="border p-2">Purpose</th>
+          </tr>
         </thead>
         <tbody>
-          <tr><td class="border p-2">Identifiers</td><td class="border p-2">Name and email address (collected solely when you complete the Contact&nbsp;Us form)</td><td class="border p-2">&bull; Responding to your inquiry<br>&bull; Maintaining a record of correspondence</td></tr>
+          <tr>
+            <td class="border p-2">Identifiers</td>
+            <td class="border p-2">Name and email address (collected solely when you complete the Contact&nbsp;Us form)</td>
+            <td class="border p-2">
+              <ul class="list-disc list-inside">
+                <li>Responding to your inquiry</li>
+                <li>Maintaining a record of correspondence</li>
+              </ul>
+            </td>
+          </tr>
         </tbody>
       </table>
       <p>We do not intentionally collect any other personal information through the Contact&nbsp;Us form, and we do not request or store sensitive information (e.g., payment data, health details).</p>


### PR DESCRIPTION
## Summary
- center the Privacy Policy heading
- tidy the privacy data table with bullet lists

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886a184a79083299d754e46f6cb21cc