### PR TITLE
Add captcha verification for contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
   <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
   <!-- Swiper Carousel -->
   <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
+  <!-- Google reCAPTCHA -->
+  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
   <style>
   body { margin: 0; }
     *, *::before, *::after {
@@ -354,10 +356,11 @@
   <section id="contact" class="py-20 bg-[var(--brand-light-alt)]">
     <div class="max-w-5xl mx-auto px-8">
       <h2 class="text-4xl font-bold text-center mb-8">Get in Touch</h2>
-      <form class="grid gap-6 max-w-xl mx-auto">
+      <form id="contact-form" class="grid gap-6 max-w-xl mx-auto">
         <input type="text" name="name" placeholder="Name" required class="w-full p-3 rounded border border-gray-300" />
         <input type="email" name="email" placeholder="Email" required class="w-full p-3 rounded border border-gray-300" />
         <textarea name="message" rows="4" placeholder="Message" required class="w-full p-3 rounded border border-gray-300"></textarea>
+        <div class="g-recaptcha" data-sitekey="YOUR_RECAPTCHA_SITE_KEY"></div>
         <button type="submit" class="bg-[var(--brand-accent)] hover:bg-[var(--brand-accent)]/90 text-white py-3 px-6 rounded-full shadow">Send Message</button>
         <p class="text-center text-sm mt-2"><a href="/privacy" class="underline hover:text-[var(--brand-accent)]">Privacy Policy</a></p>
       </form>
@@ -437,6 +440,16 @@
         }
       });
     });
+
+    const contactForm = document.getElementById('contact-form');
+    if (contactForm) {
+      contactForm.addEventListener('submit', (e) => {
+        if (typeof grecaptcha !== 'undefined' && grecaptcha.getResponse() === '') {
+          e.preventDefault();
+          alert('Please complete the captcha.');
+        }
+      });
+    }
   </script>
 </body>
 </html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -86,7 +86,7 @@
     <div class="max-w-4xl mx-auto px-8 space-y-4 text-lg">
       <h1 class="text-4xl font-bold mb-4 text-center">Privacy Policy</h1>
       <p><strong>Shouting Grounds Coffee&nbsp;Co.</strong></p>
-      <p class="italic">Last updated: [Month&nbsp;Day,&nbsp;2025]</p>
+      <p class="italic">Last updated: August&nbsp;2,&nbsp;2025</p>
       <p>Shouting Grounds Coffee&nbsp;Co. (“Shouting&nbsp;Grounds,” “we,” “our,” or “us”) values your privacy. This Privacy&nbsp;Policy explains how we collect, use, disclose, and safeguard the only personal information we request on our website—your name and email address—when you use our Contact&nbsp;Us form. By visiting the site or submitting information, you agree to the practices described below.</p>
       <h2 class="text-2xl font-semibold mt-6">1. Information&nbsp;We&nbsp;Collect&nbsp;&amp;&nbsp;Why</h2>
       <table class="min-w-full text-left border border-gray-300 my-4">
@@ -108,9 +108,19 @@
               </ul>
             </td>
           </tr>
+          <tr>
+            <td class="border p-2">Security</td>
+            <td class="border p-2">reCAPTCHA response token and related data handled by Google</td>
+            <td class="border p-2">
+              <ul class="list-disc list-inside">
+                <li>Protecting the site from spam and abuse</li>
+              </ul>
+            </td>
+          </tr>
         </tbody>
       </table>
       <p>We do not intentionally collect any other personal information through the Contact&nbsp;Us form, and we do not request or store sensitive information (e.g., payment data, health details).</p>
+      <p>The Contact&nbsp;Us form is protected by reCAPTCHA and the <a href="https://policies.google.com/privacy" class="underline">Google&nbsp;Privacy&nbsp;Policy</a> and <a href="https://policies.google.com/terms" class="underline">Terms&nbsp;of&nbsp;Service</a> apply.</p>
       <p><em>Note: Like most websites, basic technical data (e.g., IP address) may be automatically logged by our hosting provider for security and operational purposes, but this data is not linked to you in a way that identifies you personally and is retained only for system integrity.</em></p>
       <h2 class="text-2xl font-semibold mt-6">2. How&nbsp;We&nbsp;Use&nbsp;Your&nbsp;Information</h2>
       <ul class="list-disc list-inside">


### PR DESCRIPTION
## Summary
- integrate Google reCAPTCHA into the contact form and block submission until the challenge is solved
- document reCAPTCHA usage and related data handling in the privacy policy

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e526381408329b8489d34b759858b