### PR TITLE
Transform bagel highlight into full-width banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,15 +205,14 @@
           <p class="text-sm">Gooey spirals loaded with cream cheese frosting that sell out fast — so ask early!</p>
         </div>
       </div>
-      <p class="text-center mt-4">
-        <span class="inline-block bg-[var(--brand-accent)] text-white py-2 px-4 rounded-full">A variety of New Yorker Bagels are served daily.</span>
-      </p>
-
-      <div class="mt-8 text-center">
-        <a href="assets/menu.pdf" class="inline-block bg-[var(--brand-accent)] hover:bg-[var(--brand-accent)]/90 text-white py-3 px-6 rounded-full shadow transition text-lg font-semibold">
-          View Full Menu
-        </a>
-      </div>
+    </div>
+    <div class="mt-4 w-full bg-[var(--brand-dark)] text-[var(--brand-light)] text-center py-2">
+      A variety of New Yorker Bagels are served daily.
+    </div>
+    <div class="max-w-5xl mx-auto px-8 text-center mt-8">
+      <a href="assets/menu.pdf" class="inline-block bg-[var(--brand-accent)] hover:bg-[var(--brand-accent)]/90 text-white py-3 px-6 rounded-full shadow transition text-lg font-semibold">
+        View Full Menu
+      </a>
     </div>
   </section>
   <!-- GALLERY SECTION -->


### PR DESCRIPTION
## Summary
- Restyle New Yorker Bagels note as a full-width banner with dark background and light text
- Keep 'View Full Menu' button centered beneath banner

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e545674148329909106b884fba8fe